### PR TITLE
Use CGI.escape instead of deprecated URI.encode

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -1,4 +1,7 @@
 # This class represents a Docker Image.
+
+require "cgi"
+
 class Docker::Image
   include Docker::Base
 
@@ -126,7 +129,7 @@ class Docker::Image
 
     # Return a specific image.
     def get(id, opts = {}, conn = Docker.connection)
-      image_json = conn.get("/images/#{URI.encode(id)}/json", opts)
+      image_json = conn.get("/images/#{CGI.escape(id)}/json", opts)
       hash = Docker::Util.parse_json(image_json) || {}
       new(conn, hash)
     end


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Silences a deprecation warning under ruby 2.7.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
