### PR TITLE
Use CGI.escape everywhere

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -343,7 +343,7 @@ class Docker::Container
 
   # Return the container with specified ID
   def self.get(id, opts = {}, conn = Docker.connection)
-    container_json = conn.get("/containers/#{URI.encode(id)}/json", opts)
+    container_json = conn.get("/containers/#{CGI.escape(id)}/json", opts)
     hash = Docker::Util.parse_json(container_json) || {}
     new(conn, hash)
   end

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -1,7 +1,4 @@
 # This class represents a Docker Image.
-
-require "cgi"
-
 class Docker::Image
   include Docker::Base
 
@@ -177,7 +174,7 @@ class Docker::Image
       # By using compare_by_identity we can create a Hash that has
       # the same key multiple times.
       query = {}.tap(&:compare_by_identity)
-      Array(names).each { |name| query['names'.dup] = URI.encode(name) }
+      Array(names).each { |name| query['names'.dup] = CGI.escape(name) }
       conn.get(
         '/images/get',
         query,

--- a/lib/docker/network.rb
+++ b/lib/docker/network.rb
@@ -34,7 +34,7 @@ class Docker::Network
   end
 
   def reload
-    network_json = @connection.get("/networks/#{URI.encode(@id)}")
+    network_json = @connection.get("/networks/#{CGI.escape(@id)}")
     hash = Docker::Util.parse_json(network_json) || {}
     @info = hash
   end
@@ -51,7 +51,7 @@ class Docker::Network
     end
 
     def get(id, opts = {}, conn = Docker.connection)
-      network_json = conn.get("/networks/#{URI.encode(id)}", opts)
+      network_json = conn.get("/networks/#{CGI.escape(id)}", opts)
       hash = Docker::Util.parse_json(network_json) || {}
       new(conn, hash)
     end
@@ -62,7 +62,7 @@ class Docker::Network
     end
 
     def remove(id, opts = {}, conn = Docker.connection)
-      conn.delete("/networks/#{URI.encode(id)}", opts)
+      conn.delete("/networks/#{CGI.escape(id)}", opts)
       nil
     end
     alias_method :delete, :remove

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -515,7 +515,7 @@ describe Docker::Image do
     let(:non_streamed) do
       Docker.connection.get(
         '/images/get',
-        'names' => URI.encode(image)
+        'names' => CGI.escape(image)
       )
     end
     let(:streamed) { '' }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The first pass of replacing URI.encode with CGI.escape was based on an open PR on the upstream repo, which only performed one replacement. Turns out there were several more that should have been replaced. 

I searched for all occurrences and replaced all. I also found that the cgi gem is loaded at a high level, so there is no need to require it in any of the subsequent files.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
